### PR TITLE
[OCK-004] fix: update _sendETH to private

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           echo "✅ Passed" >> $GITHUB_STEP_SUMMARY
 
   test:
-    needs: ["lint", "build"]
+    needs: ["build"]
     runs-on: "ubuntu-latest"
     steps:
       - name: "Check out the repo"

--- a/src/BasicCostPolicy.sol
+++ b/src/BasicCostPolicy.sol
@@ -19,7 +19,9 @@ contract BasicCostPolicy is ICostPolicy, Ownable2Step {
         uint256 _oneTimeFee,
         uint256 _perUserFee,
         uint256 _minUserCount
-    ) Ownable(initialOwner) {
+    )
+        Ownable(initialOwner)
+    {
         oneTimeFee = _oneTimeFee;
         perUserFee = _perUserFee;
         maxFreeUserCount = _minUserCount;

--- a/src/ERC20BatchSender.sol
+++ b/src/ERC20BatchSender.sol
@@ -26,21 +26,14 @@ contract ERC20BatchSender is UpgradeableBase {
         _disableInitializers();
     }
 
-    function initialize(
-        address manager,
-        ICostPolicy _costPolicy,
-        address _feeRecipient
-    ) public initializer {
+    function initialize(address manager, ICostPolicy _costPolicy, address _feeRecipient) public initializer {
         __UpgradeableBase_init(_msgSender());
         _grantManagerRole(manager);
         costPolicy = _costPolicy;
         feeRecipient = _feeRecipient;
     }
 
-    function reinitialize(
-        ICostPolicy _costPolicy,
-        address _feeRecipient
-    ) public reinitializer(2) {
+    function reinitialize(ICostPolicy _costPolicy, address _feeRecipient) public reinitializer(2) {
         costPolicy = _costPolicy;
         feeRecipient = _feeRecipient;
     }

--- a/src/ERC20BatchSender.sol
+++ b/src/ERC20BatchSender.sol
@@ -102,7 +102,7 @@ contract ERC20BatchSender is UpgradeableBase {
         emit BatchSend(address(_token), _accounts, _amounts, _typeId);
     }
 
-    function _sendETH(address[] calldata _accounts, uint256[] calldata _amounts, uint256 _typeId) public payable {
+    function _sendETH(address[] calldata _accounts, uint256[] calldata _amounts, uint256 _typeId) private payable {
         for (uint256 i = 0; i < _accounts.length; i++) {
             address account = _accounts[i];
             uint256 amount = _amounts[i];

--- a/src/ERC20BatchSender.sol
+++ b/src/ERC20BatchSender.sol
@@ -102,7 +102,7 @@ contract ERC20BatchSender is UpgradeableBase {
         emit BatchSend(address(_token), _accounts, _amounts, _typeId);
     }
 
-    function _sendETH(address[] calldata _accounts, uint256[] calldata _amounts, uint256 _typeId) private payable {
+    function _sendETH(address[] calldata _accounts, uint256[] calldata _amounts, uint256 _typeId) private {
         for (uint256 i = 0; i < _accounts.length; i++) {
             address account = _accounts[i];
             uint256 amount = _amounts[i];

--- a/src/ERC20BatchSenderV2.sol
+++ b/src/ERC20BatchSenderV2.sol
@@ -102,7 +102,7 @@ contract ERC20BatchSenderV2 is UpgradeableBase {
         emit BatchSend(address(_token), _accounts, _amounts, _typeId);
     }
 
-    function _sendETH(address[] calldata _accounts, uint256[] calldata _amounts, uint256 _typeId) private payable {
+    function _sendETH(address[] calldata _accounts, uint256[] calldata _amounts, uint256 _typeId) private {
         for (uint256 i = 0; i < _accounts.length; i++) {
             address account = _accounts[i];
             uint256 amount = _amounts[i];

--- a/src/ERC20BatchSenderV2.sol
+++ b/src/ERC20BatchSenderV2.sol
@@ -26,21 +26,14 @@ contract ERC20BatchSenderV2 is UpgradeableBase {
         _disableInitializers();
     }
 
-    function initialize(
-        address manager,
-        ICostPolicyV2 _costPolicy,
-        address _feeRecipient
-    ) public initializer {
+    function initialize(address manager, ICostPolicyV2 _costPolicy, address _feeRecipient) public initializer {
         __UpgradeableBase_init(_msgSender());
         _grantManagerRole(manager);
         costPolicy = _costPolicy;
         feeRecipient = _feeRecipient;
     }
 
-    function reinitialize(
-        ICostPolicyV2 _costPolicy,
-        address _feeRecipient
-    ) public reinitializer(3) {
+    function reinitialize(ICostPolicyV2 _costPolicy, address _feeRecipient) public reinitializer(3) {
         costPolicy = _costPolicy;
         feeRecipient = _feeRecipient;
     }
@@ -61,7 +54,8 @@ contract ERC20BatchSenderV2 is UpgradeableBase {
             revert LengthMismatch();
         }
 
-        uint256 cost = costPolicy.calculateCost(address(_token), _msgSender(), _accounts.length, _amounts.length, _typeId);
+        uint256 cost =
+            costPolicy.calculateCost(address(_token), _msgSender(), _accounts.length, _amounts.length, _typeId);
         if (msg.value < cost) {
             revert InsufficientCost();
         }

--- a/src/ERC20BatchSenderV2.sol
+++ b/src/ERC20BatchSenderV2.sol
@@ -15,6 +15,7 @@ contract ERC20BatchSenderV2 is UpgradeableBase {
 
     error InsufficientCost();
     error LengthMismatch();
+    error InvalidTotalAmount(uint256 actual, uint256 expected);
 
     event BatchSend(address indexed token, address[] accounts, uint256[] amounts, uint256 typeId);
     event ERC20TokenWithdrawn(IERC20 _token, address _recipient, uint256 _value);
@@ -64,8 +65,9 @@ contract ERC20BatchSenderV2 is UpgradeableBase {
         if (msg.value < cost) {
             revert InsufficientCost();
         }
-        _sendFee(cost);
+        _checkTotalAmount(_amounts, _totalAmount);
 
+        _sendFee(cost);
         _token.safeTransferFrom(_msgSender(), address(this), _totalAmount);
         _send(_token, _accounts, _amounts, _typeId);
     }
@@ -87,8 +89,9 @@ contract ERC20BatchSenderV2 is UpgradeableBase {
         if (msg.value < _totalAmount + cost) {
             revert InsufficientCost();
         }
-        _sendFee(cost);
+        _checkTotalAmount(_amounts, _totalAmount);
 
+        _sendFee(cost);
         _sendETH(_accounts, _amounts, _typeId);
     }
 
@@ -154,5 +157,15 @@ contract ERC20BatchSenderV2 is UpgradeableBase {
     function setCostPolicy(ICostPolicyV2 _costPolicy) public onlyManager {
         costPolicy = _costPolicy;
         emit CostPolicyUpdated(_costPolicy);
+    }
+
+    function _checkTotalAmount(uint256[] calldata _amounts, uint256 _totalAmount) internal pure {
+        uint256 sumAmount = 0;
+        for (uint256 i = 0; i < _amounts.length; i++) {
+            sumAmount += _amounts[i];
+        }
+        if (sumAmount != _totalAmount) {
+            revert InvalidTotalAmount(sumAmount, _totalAmount);
+        }
     }
 }

--- a/src/ERC20BatchSenderV2.sol
+++ b/src/ERC20BatchSenderV2.sol
@@ -102,7 +102,7 @@ contract ERC20BatchSenderV2 is UpgradeableBase {
         emit BatchSend(address(_token), _accounts, _amounts, _typeId);
     }
 
-    function _sendETH(address[] calldata _accounts, uint256[] calldata _amounts, uint256 _typeId) public payable {
+    function _sendETH(address[] calldata _accounts, uint256[] calldata _amounts, uint256 _typeId) private payable {
         for (uint256 i = 0; i < _accounts.length; i++) {
             address account = _accounts[i];
             uint256 amount = _amounts[i];

--- a/src/WhitelistCostPolicy.sol
+++ b/src/WhitelistCostPolicy.sol
@@ -4,13 +4,13 @@ pragma solidity 0.8.23;
 import { ICostPolicyV2 } from "./interfaces/ICostPolicyV2.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
-import {ICostPolicy} from "./interfaces/ICostPolicy.sol";
+import { ICostPolicy } from "./interfaces/ICostPolicy.sol";
 
 contract WhitelistCostPolicy is ICostPolicyV2, Ownable2Step {
     uint256 public oneTimeFee;
     uint256 public perUserFee;
     uint256 public maxFreeUserCount;
-    mapping (address => bool) public whitelist;
+    mapping(address => bool) public whitelist;
 
     event OneTimeFeeUpdated(uint256 _oneTimeFee);
     event PerUserFeeUpdated(uint256 _perUserFee);
@@ -22,7 +22,9 @@ contract WhitelistCostPolicy is ICostPolicyV2, Ownable2Step {
         uint256 _oneTimeFee,
         uint256 _perUserFee,
         uint256 _minUserCount
-    ) Ownable(initialOwner) {
+    )
+        Ownable(initialOwner)
+    {
         oneTimeFee = _oneTimeFee;
         perUserFee = _perUserFee;
         maxFreeUserCount = _minUserCount;

--- a/test/E2E.t.sol
+++ b/test/E2E.t.sol
@@ -18,7 +18,7 @@ contract E2ETest is TestBase {
         assertEq(FEE_RECIPIENT.balance, 0);
         assertEq(token.balanceOf(address(10_000)), 0);
         assertEq(token.balanceOf(address(10_001)), 100);
-        assertEq(token.balanceOf(address(10_199)), 19900);
+        assertEq(token.balanceOf(address(10_199)), 19_900);
     }
 
     function test_Send200_TakesFee_IfTheUserIsNotInTheWhitelist() external {
@@ -31,6 +31,6 @@ contract E2ETest is TestBase {
         assertEq(FEE_RECIPIENT.balance, whitelistCostPolicy.oneTimeFee());
         assertEq(token.balanceOf(address(10_000)), 0);
         assertEq(token.balanceOf(address(10_001)), 100);
-        assertEq(token.balanceOf(address(10_199)), 19900);
+        assertEq(token.balanceOf(address(10_199)), 19_900);
     }
 }

--- a/test/ERC20BatchTransfer.t.sol
+++ b/test/ERC20BatchTransfer.t.sol
@@ -42,7 +42,8 @@ contract ERC20BatchTransferTest is TestBase {
 
     function test_SendOneUser() external {
         uint256 cost = whitelistCostPolicy.oneTimeFee();
-        uint256 total = 300;
+        uint256 wrongTotal = 300;
+        uint256 correctTotal = 100;
         _faucet(address(this), 1000);
         deal(address(this), cost);
 
@@ -55,7 +56,11 @@ contract ERC20BatchTransferTest is TestBase {
         amounts[0] = 100;
 
         uint256 typeId = 0;
-        batchSender.send{ value: cost }(token, recipients, amounts, total, typeId);
+        vm.expectRevert(abi.encodeWithSelector(ERC20BatchSenderV2.InvalidTotalAmount.selector, 100, 300));
+        batchSender.send{ value: cost }(token, recipients, amounts, wrongTotal, typeId);
+
+        batchSender.send{ value: cost }(token, recipients, amounts, correctTotal, typeId);
+        assertEq(token.balanceOf(ALICE), 100);
     }
 
     function test_Send() external {
@@ -76,6 +81,8 @@ contract ERC20BatchTransferTest is TestBase {
 
         uint256 typeId = 0;
         batchSender.send{ value: cost }(token, recipients, amounts, total, typeId);
+        assertEq(token.balanceOf(ALICE), 100);
+        assertEq(token.balanceOf(BOB), 200);
     }
 
     function test_Send200_ReceiveFee() external {

--- a/test/ForkE2E.t.sol
+++ b/test/ForkE2E.t.sol
@@ -26,11 +26,10 @@ contract ForkE2ETest is TestBase {
         _send200WithoutFaucet();
         uint256 balanceAfter = batchSender.feeRecipient().balance;
 
-
         assertEq(balanceBefore, balanceAfter);
         assertEq(token.balanceOf(address(10_000)), 0);
         assertEq(token.balanceOf(address(10_001)), 100);
-        assertEq(token.balanceOf(address(10_199)), 19900);
+        assertEq(token.balanceOf(address(10_199)), 19_900);
     }
 
     function test_Send200_TakesFee_IfTheUserIsNotInTheWhitelist() external {
@@ -44,7 +43,7 @@ contract ForkE2ETest is TestBase {
         assertEq(balanceAfter, balanceBefore + whitelistCostPolicy.oneTimeFee());
         assertEq(token.balanceOf(address(10_000)), 0);
         assertEq(token.balanceOf(address(10_001)), 100);
-        assertEq(token.balanceOf(address(10_199)), 19900);
+        assertEq(token.balanceOf(address(10_199)), 19_900);
     }
 
     // same as _send200

--- a/test/TestBase.sol
+++ b/test/TestBase.sol
@@ -9,7 +9,7 @@ import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy
 import { ERC20BatchSenderV2 } from "src/ERC20BatchSenderV2.sol";
 import { BasicCostPolicy } from "src/BasicCostPolicy.sol";
 import { ICostPolicyV2 } from "src/interfaces/ICostPolicyV2.sol";
-import { WhitelistCostPolicy} from "src/WhitelistCostPolicy.sol";
+import { WhitelistCostPolicy } from "src/WhitelistCostPolicy.sol";
 import { MockERC20 } from "src/test/MockERC20.sol";
 
 contract TestBase is PRBTest, StdCheats {

--- a/test/WhitelistCostPolicy.t.sol
+++ b/test/WhitelistCostPolicy.t.sol
@@ -12,7 +12,10 @@ contract WhitelistCostPolicyTest is TestBase {
     }
 
     function test_CalculateCost_WhenUserCountIsBiggerThanMaxFreeUserCount() public {
-        assertEq(whitelistCostPolicy.calculateCost(address(token), ALICE, MIN_USER_COUNT + 1, 100, 0), whitelistCostPolicy.oneTimeFee());
+        assertEq(
+            whitelistCostPolicy.calculateCost(address(token), ALICE, MIN_USER_COUNT + 1, 100, 0),
+            whitelistCostPolicy.oneTimeFee()
+        );
     }
 
     function test_CalculateCost_WhenUserCountIsLessOrEqualThanMaxFreeUserCount() public {
@@ -28,7 +31,10 @@ contract WhitelistCostPolicyTest is TestBase {
     function test_CalculateCost_WhenUserIsRemovedFromWhitelist() public {
         vm.prank(MANAGER);
         whitelistCostPolicy.removeWhitelist(ALICE);
-        assertEq(whitelistCostPolicy.calculateCost(address(token), ALICE, MIN_USER_COUNT + 1, 100, 0), whitelistCostPolicy.oneTimeFee());
+        assertEq(
+            whitelistCostPolicy.calculateCost(address(token), ALICE, MIN_USER_COUNT + 1, 100, 0),
+            whitelistCostPolicy.oneTimeFee()
+        );
     }
 
     function test_RevertWhen_AddWhitelist_NotByOwner() public {


### PR DESCRIPTION
## Description
Fix for the audit report.
1. Oneclicksender-1 Users may choose a cheaper type.
2. Oneclicksender-2 This is intended to keep the same interface for all policy contracts.
3. Oneclicksender-3 The contract does not hold any assets, but the visibility is better to be changed. Fixed in [6d2426d](https://github.com/ModoriLabs/oneclicksender-contract/commit/6d2426dc598c8c0bd5b656c048f23972485828a3).
4. Oneclicksender-4 This is intended to reduce gas fee to calculate the sum.
5. For reentrancy, we trust `feeRecipient` address, so replace reentrancy modifier with the Check-Effect-Interaction pattern.